### PR TITLE
Fix README location

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     license=open("LICENSE.txt").read(),
     packages=find_packages(),
     description="plotting in the terminal",
-    long_description=open("README.txt").read(),
+    long_description=open("README.md").read(),
     scripts=['bin/hist', 'bin/scatter'],
 )
 


### PR DESCRIPTION
`setup.py` has been referencing `README.txt`; as far as I can tell, this file
has never existed in the repo, always instead being named `README.md`.

Now the path is correct.
