### PR TITLE
Fix typo

### DIFF
--- a/bashplotlib/histogram.py
+++ b/bashplotlib/histogram.py
@@ -82,7 +82,7 @@ def plot_hist(f, height=20.0, bincount=None, pch="o", colour="white", title="", 
 
     bins = list(calc_bins(n, min_val, max_val, bincount))
     hist = {}
-    for i in range(len(bings)):
+    for i in range(len(bins)):
         hist[i] = 0
     for number in read_numbers(f):
         for i, b in enumerate(bins):


### PR DESCRIPTION
In 607f7782, the `bins` variable was accidentally changed to `bings`, which
produces a `NameError` when running `bin/hist`.  This commit corrects that.
