### PR TITLE
max values and y-val of 0

### DIFF
--- a/bashplotlib/histogram.py
+++ b/bashplotlib/histogram.py
@@ -86,13 +86,15 @@ def plot_hist(f, height=20.0, bincount=None, pch="o", colour="white", title="", 
         hist[i] = 0
     for number in read_numbers(f):
         for i, b in enumerate(bins):
-            if number < b:
+            if number <= b:
                 hist[i] += 1
                 break
+        if number == max_val and max_val > bins[len(bins) - 1]:
+            hist[len(hist) - 1] += 1
 
     min_y, max_y = min(hist.values()), max(hist.values())
 
-    ys = list(drange(min_y, max_y, (max_y-min_y)/height))
+    ys = list(drange(max(min_y, 1), max_y + 1, (max_y-min_y)/height))
     ys.reverse()
 
     nlen = max(len(str(min_y)), len(str(max_y))) + 1
@@ -112,7 +114,7 @@ def plot_hist(f, height=20.0, bincount=None, pch="o", colour="white", title="", 
         print ylab,
 
         for i in range(len(hist)):
-            if y < hist[i]:
+            if int(y) <= hist[i]:
                 printcolor(pch, True, colour)
             else:
                 printcolor(" ", True, colour)


### PR DESCRIPTION
include max data values (previously were left out of plot)
include max y values (previously were left off of y axis)
show y scale such that height of column in histogram corresponds to
  correct y value (previously corresponded to y-1)
no need to include 0 in ys. Rather, start ys at min of 1, and
  leave cols with y val of 0 empty.

![cmd](https://cloud.githubusercontent.com/assets/529129/2574582/819d81a8-b936-11e3-81cd-5e4cbbeb24b2.png)
![bball_hist](https://cloud.githubusercontent.com/assets/529129/2574668/07b41f94-b938-11e3-8503-9d4f7931c361.png)
![before](https://cloud.githubusercontent.com/assets/529129/2574584/8a52da28-b936-11e3-8a80-c8ad5bc07bfe.png)
![after](https://cloud.githubusercontent.com/assets/529129/2574583/85fc2830-b936-11e3-8814-e4e3aec36e0f.png)
