### PR TITLE
modify x-label printouts

### DIFF
--- a/bashplotlib/histogram.py
+++ b/bashplotlib/histogram.py
@@ -14,7 +14,10 @@ def calc_bins(n, min_val, max_val, h=None, binwidth=None):
     if binwidth is None:
         binwidth = (max_val - min_val) / h
     for b in drange(min_val, max_val, step=binwidth, include_stop=True):
-        yield b
+        if b.is_integer():
+            yield int(b)
+        else:
+            yield b
 
 def read_numbers(numbers):
     "read the input data in the most optimal way"


### PR DESCRIPTION
trim x-labels to smallest non-zero decimal, and drop decimal place if
  the x-value is an integer

data
![hist](https://cloud.githubusercontent.com/assets/529129/2726605/403b4b7a-c5be-11e3-8552-fc9f5f37e581.png)
cmd
![cmd](https://cloud.githubusercontent.com/assets/529129/2726607/46baffa4-c5be-11e3-94f8-78484e36b7d5.png)
before
![before](https://cloud.githubusercontent.com/assets/529129/2726609/54d1f782-c5be-11e3-8547-46da49e21d68.png)
after
![after](https://cloud.githubusercontent.com/assets/529129/2726611/5a578df2-c5be-11e3-81e2-cf36ad9b88e5.png)

cmd 2
![cmd 2](https://cloud.githubusercontent.com/assets/529129/2726629/e9962352-c5be-11e3-83b4-ddf92ed1086f.png)
unchanged
![unchanged](https://cloud.githubusercontent.com/assets/529129/2726631/f088cde0-c5be-11e3-8fad-080f74771a31.png)
