### PR TITLE
Improves the setting of xlims in the scatter plot

### DIFF
--- a/bashplotlib/scatterplot.py
+++ b/bashplotlib/scatterplot.py
@@ -17,7 +17,8 @@ def get_scale(series, is_y=False, steps=20):
     min_val = min(series)
     max_val = max(series)
     scaled_series = []
-    for x in drange(min_val, max_val, (max_val - min_val) / steps):
+    for x in drange(min_val, max_val, (max_val - min_val) / steps,
+                    include_stop=True):
         if x > 0 and scaled_series and max(scaled_series) < 0:
             scaled_series.append(0.0)
         scaled_series.append(x)
@@ -65,16 +66,9 @@ def plot_scatter(f, xs, ys, size, pch, colour, title):
             for (i, (xp, yp)) in enumerate(zip(xs, ys)):
                 if xp <= x and yp >= y and (xp, yp) not in plotted:
                     point = pch
-                    #point = str(i)
                     plotted.add((xp, yp))
-            if x == 0 and y == 0:
-                point = "o"
-            elif x == 0:
-                point = "|"
-            elif y == 0:
-                point = "-"
             printcolour(point, True, colour)
-        print("|")
+        print(" |")
     print("-" * (2 * len(get_scale(xs, False, size)) + 2))
 
 


### PR DESCRIPTION
- Fixes a bug in which the right-most data point is not includes by
  using the `drange` include_stop argument
- Removes unneccersery code that is repeating the operation of plotting
  a border
- Add a space between the final data point and the right-hand border

In the master branch, the `texas` example looks like this:
![02](https://cloud.githubusercontent.com/assets/1926734/10342425/eba7d44c-6d10-11e5-86a6-2780c5144ca6.png)

This PR gives:
![01](https://cloud.githubusercontent.com/assets/1926734/10342424/eba76340-6d10-11e5-9c5e-94e200d33368.png)

Essentially including the right-most data points and adding a space (as there is on the left-hand-side).
