### PR TITLE
Adds color support to scatter plot

### DIFF
--- a/bashplotlib/scatterplot.py
+++ b/bashplotlib/scatterplot.py
@@ -17,7 +17,8 @@ def get_scale(series, is_y=False, steps=20):
     min_val = min(series)
     max_val = max(series)
     scaled_series = []
-    for x in drange(min_val, max_val, (max_val - min_val) / steps):
+    for x in drange(min_val, max_val, (max_val - min_val) / steps,
+                    include_stop=True):
         if x > 0 and scaled_series and max(scaled_series) < 0:
             scaled_series.append(0.0)
         scaled_series.append(x)
@@ -65,16 +66,9 @@ def plot_scatter(f, xs, ys, size, pch, colour, title):
             for (i, (xp, yp)) in enumerate(zip(xs, ys)):
                 if xp <= x and yp >= y and (xp, yp) not in plotted:
                     point = pch
-                    #point = str(i)
                     plotted.add((xp, yp))
-            if x == 0 and y == 0:
-                point = "o"
-            elif x == 0:
-                point = "|"
-            elif y == 0:
-                point = "-"
             printcolour(point, True, colour)
-        print("|")
+        print(" |")
     print("-" * (2 * len(get_scale(xs, False, size)) + 2))
 
 

--- a/bashplotlib/scatterplot.py
+++ b/bashplotlib/scatterplot.py
@@ -46,9 +46,13 @@ def plot_scatter(f, xs, ys, size, pch, colour, title):
         if isinstance(f, str):
             f = open(f)
 
-        data = [tuple(map(float, line.strip().split(','))) for line in f]
-        xs = [i[0] for i in data]
-        ys = [i[1] for i in data]
+        data = [tuple(line.strip().split(',')) for line in f]
+        xs = [float(i[0]) for i in data]
+        ys = [float(i[1]) for i in data]
+        if len(data[0]) > 2:
+            cs = [i[2].strip() for i in data]
+        else:
+            cs = None
     else:
         xs = [float(str(row).strip()) for row in open(xs)]
         ys = [float(str(row).strip()) for row in open(ys)]
@@ -67,6 +71,8 @@ def plot_scatter(f, xs, ys, size, pch, colour, title):
                 if xp <= x and yp >= y and (xp, yp) not in plotted:
                     point = pch
                     plotted.add((xp, yp))
+                    if cs:
+                        colour = cs[i]
             printcolour(point, True, colour)
         print(" |")
     print("-" * (2 * len(get_scale(xs, False, size)) + 2))


### PR DESCRIPTION
This is an idea for how to include colour support for the `scatterplot`. It allows the user to add a third column to the csv file, so for example:

```
0, 1, red
2, 3, aqua
0, 0, pink
```

To illustrate the output here is the output of a test case

![01](https://cloud.githubusercontent.com/assets/1926734/10343769/73ed9872-6d17-11e5-977b-08bcb67071b9.png)

This is committed with the changes from the other PR I made, so I wouldn't recommend including it before that is merged to master (I am happy to close this and make a new one if you are interested).

As an aside I am sorry to have sent to PRs today, I just happened to need this for some testing on a server and so I thought I'd share the work. I won't be offended in the least if you have your own plans and want to do things differently.

Best,

Greg 
