### PR TITLE
Fix formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ If you want to use bashplotlib from python, just import histogram and scatterplo
 from bashplotlib.scatterplot import plot_scatter
 ```
 <img src="examples/img/scatterplothelp.png">
+
 ```
 from bashplotlib.histogram import plot_hist
 ```
+
 <img src="examples/img/histogramhelp.png">
 
 ## examples


### PR DESCRIPTION
I added a few newline to fix the formatting around the `from bashplotlib.histogram import plot_hist` example where the backticks were showing. Thanks! :-) 