### PR TITLE
Unambiguous abbreviations of x-labels in histogram

### DIFF
--- a/bashplotlib/histogram.py
+++ b/bashplotlib/histogram.py
@@ -182,11 +182,12 @@ def plot_hist(f, height=20.0, bincount=None, binwidth=None, pch="o", colour="def
     print(" " * (nlen + 1) + "-" * len(xs))
 
     if xlab:
-        xlen = len(str(float((max_y) / height) + max_y))
+        labels = abbreviate([str(b) for b in bins])
+        xlen = len(labels[0])
         for i in range(0, xlen):
             printcolour(" " * (nlen + 1), True, colour)
             for x in range(0, len(hist)):
-                num = str(bins[x])
+                num = labels[x]
                 if x % 2 != 0:
                     pass
                 elif i < len(num):

--- a/bashplotlib/utils/helpers.py
+++ b/bashplotlib/utils/helpers.py
@@ -64,6 +64,18 @@ def drange(start, stop, step=1.0, include_stop=False):
             r = round(r, 10)
 
 
+def abbreviate(labels, rfill=' '):
+    """
+    Abbreviate labels without introducing ambiguities.
+    """
+    max_len = max(len(l) for l in labels)
+    for i in range(1, max_len):
+        abbrev = [l[:i].ljust(i, rfill) for l in labels]
+        if len(abbrev) == len(set(abbrev)):
+            break
+    return abbrev
+
+
 def box_text(text, width, offset=0):
     """
     Return text inside an ascii textbox

--- a/examples/sample.sh
+++ b/examples/sample.sh
@@ -22,6 +22,9 @@ hist --file "${dir}/data/exp.txt" --colour blue
 echo 'changing the shape of the point'
 hist --file "${dir}/data/exp.txt" --pch .
 
+echo 'adding x-labels'
+hist --file "${dir}/data/exp.txt" --pch . --xlab
+
 #echo 'using stdin'
 #curl -sL https://dl.dropbox.com/u/49171662/example.txt | hist
 


### PR DESCRIPTION
The logic behind the choice of string length of x-labels is quite obscure to me, but I believe that the best we can do is to detect the minimum length permitting to distinguish one label from the next one.
Implementation is probably not the most efficient one, but I tried to make is as readable as possible, taking into account that we do not expect too many bins (like thousands or millions).