### PR TITLE
Fix several ResourceWarnings: unclose file

### DIFF
--- a/bashplotlib/histogram.py
+++ b/bashplotlib/histogram.py
@@ -42,8 +42,9 @@ def read_numbers(numbers):
         for number in numbers:
             yield float(str(number).strip())
     else:
-        for number in open(numbers):
-            yield float(number.strip())
+        with open(numbers) as fh:
+            for number in fh:
+                yield float(number.strip())
 
 
 def run_demo():
@@ -106,7 +107,8 @@ def plot_hist(f, height=20.0, bincount=None, binwidth=None, pch="o", colour="def
         pch = "o"
 
     if isinstance(f, str):
-        f = open(f).readlines()
+        with open(f) as fh:
+            f = fh.readlines()
 
     min_val, max_val = None, None
     n, mean, sd = 0.0, 0.0, 0.0

--- a/bashplotlib/scatterplot.py
+++ b/bashplotlib/scatterplot.py
@@ -42,20 +42,22 @@ def plot_scatter(f, xs, ys, size, pch, colour, title):
         title -- title of the plot
     """
 
+    cs = None
     if f:
         if isinstance(f, str):
-            f = open(f)
-
-        data = [tuple(line.strip().split(',')) for line in f]
+            with open(f) as fh:
+                data = [tuple(line.strip().split(',')) for line in fh]
+        else:
+            data = [tuple(line.strip().split(',')) for line in f]
         xs = [float(i[0]) for i in data]
         ys = [float(i[1]) for i in data]
         if len(data[0]) > 2:
             cs = [i[2].strip() for i in data]
-        else:
-            cs = None
     else:
-        xs = [float(str(row).strip()) for row in open(xs)]
-        ys = [float(str(row).strip()) for row in open(ys)]
+        with open(xs) as fh:
+            xs = [float(str(row).strip()) for row in fh]
+        with open(ys) as fh:
+            ys = [float(str(row).strip()) for row in fh]
 
     plotted = set()
 

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,9 @@
 
 from setuptools import find_packages, setup
 
+with open("README.rst") as fh:
+    long_description = fh.read()
+
 setup(
     name="bashplotlib",
     version="0.6.5",
@@ -11,7 +14,7 @@ setup(
     license="BSD",
     packages=find_packages(),
     description="plotting in the terminal",
-    long_description=open("README.rst").read(),
+    long_description=long_description,
     entry_points = {
         'console_scripts': [
             'hist=bashplotlib.histogram:main',


### PR DESCRIPTION
Hello,

This is a little patch for resource leaks such as:
```shell
$ python setup.py install
setup.py:14: ResourceWarning: unclosed file <_io.TextIOWrapper name='README.rst' mode='r' encoding='UTF-8'>
  long_description=open("README.rst").read(),
running install
...
```
```shell
$ bash examples/sample.sh
scatterplot.py:100: ResourceWarning: unclosed file <_io.TextIOWrapper name='examples/data/texas.txt' mode='r' encoding='UTF-8'>
  plot_scatter(opts.f, opts.x, opts.y, opts.size, opts.pch, opts.colour, opts.t)
with x and y coords
scatterplot.py:57: ResourceWarning: unclosed file <_io.TextIOWrapper name='examples/data/x_test.txt' mode='r' encoding='UTF-8'>
  xs = [float(str(row).strip()) for row in open(xs)]
scatterplot.py:58: ResourceWarning: unclosed file <_io.TextIOWrapper name='examples/data/y_test.txt' mode='r' encoding='UTF-8'>
  ys = [float(str(row).strip()) for row in open(ys)]

histogram.py:109: ResourceWarning: unclosed file <_io.TextIOWrapper name='examples/data/exp.txt' mode='r' encoding='UTF-8'>
  f = open(f).readlines()
```

I also fixed this error:
```python
Traceback (most recent call last):
  File ".../bin/scatter", line 11, in <module>
    load_entry_point('bashplotlib==0.6.5', 'console_scripts', 'scatter')()
  File "scatterplot.py", line 100, in main
    plot_scatter(opts.f, opts.x, opts.y, opts.size, opts.pch, opts.colour, opts.t)
  File "scatterplot.py", line 74, in plot_scatter
    if cs:
UnboundLocalError: local variable 'cs' referenced before assignment
```

Signed-off-by: Mickaël Schoentgen <contact@tiger-222.fr>